### PR TITLE
Remove scheduled cron from sync workflows — dispatch-only

### DIFF
--- a/.github/workflows/sync-garden.yml
+++ b/.github/workflows/sync-garden.yml
@@ -6,7 +6,6 @@
 # Triggers:
 #   - Manual (workflow_dispatch)
 #   - When vault repo pushes (repository_dispatch from vault's webhook workflow)
-#   - Daily cron (backup in case webhook misses)
 
 name: Sync Garden from Vault
 
@@ -14,8 +13,6 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [sync-garden]
-  schedule:
-    - cron: '0 6 * * *' # 6am UTC daily
 
 jobs:
   sync-garden:

--- a/.github/workflows/sync-research.yml
+++ b/.github/workflows/sync-research.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch: # Allows manual triggering
   repository_dispatch:
     types: [sync-research] # Triggered when research repo pushes to main
-  schedule:
-    # Run daily at midnight UTC to check for updates (backup)
-    - cron: '0 0 * * *'
 
 jobs:
   sync-research:


### PR DESCRIPTION
Both garden and research sync are triggered only by:
- Manual workflow_dispatch
- repository_dispatch from their respective source repos