### PR TITLE
Fix 404 on newly added book pages

### DIFF
--- a/pages/books/[[...slug]].tsx
+++ b/pages/books/[[...slug]].tsx
@@ -84,7 +84,7 @@ export async function getStaticPaths() {
                 params: { slug: [slug.replace('/books/', '')] }
             }))
         ],
-        fallback: false, // Pre-render all pages at build time for better performance
+        fallback: "blocking",
     };
 }
 


### PR DESCRIPTION
## Summary
- **Fix book page 404s**: Changed `fallback: false` to `fallback: "blocking"` in `getStaticPaths` for the books route. Books added to Supabase after a deploy were visible in the bookshelf widget (via ISR data revalidation) but returned 404 when clicked, because their individual pages were never generated at build time.
- **Remove scheduled cron from sync workflows**: Dispatch-only triggers for garden/research sync (from prior commit).

## Why
With `fallback: false`, `getStaticPaths` only runs at build time — any book added to Supabase afterward simply has no page. `fallback: "blocking"` makes Next.js server-render the page on first request and cache it statically from then on.

## Test plan
- [ ] Deploy and verify that books added after the last build (from "The Irrational Decision" onward) load correctly when clicked
- [ ] Verify older book pages still work as before
- [ ] Confirm bookshelf widget continues to display all books

🤖 Generated with [Claude Code](https://claude.com/claude-code)